### PR TITLE
Update stepper library dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,5 +6,5 @@ monitor_speed = 115200
 lib_deps =
   adafruit/Adafruit SSD1306
   adafruit/Adafruit GFX Library
-  accelstepper
+  AccelStepper
   RobTillaart/AS5600


### PR DESCRIPTION
## Summary
- ensure PlatformIO uses the `AccelStepper` library

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842a70bb0808323829c4328e7f987da