### PR TITLE
Add .gitignore for PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pio/
+.vscode/
+*.elf
+*.bin


### PR DESCRIPTION
## Summary
- add common PlatformIO `.gitignore` entries to prevent generated binaries and build directories from being tracked

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a7003540832398fc0db0e31c02ca