### PR TITLE
Add discovery response and joystick smoothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,19 @@ for use with [PlatformIO](https://platformio.org/) and the Arduino framework.
 
 
 ## Building
-Install PlatformIO and run the build from this directory:
+Install PlatformIO and run the build from this directory.
+There are separate environments for the receiver and sender:
 
 ```bash
-platformio run
+platformio run -e receiver  # build receiver firmware
+platformio run -e sender    # build sender firmware
 ```
 
 Upload the firmware using:
 
 ```bash
-platformio run --target upload
+platformio run -e receiver --target upload
+platformio run -e sender --target upload
 ```
 
 The configuration for PlatformIO is stored in `platformio.ini`.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-[env:esp32dev]
+[env:receiver]
 platform = espressif32
 board = esp32dev
 framework = arduino
@@ -8,3 +8,14 @@ lib_deps =
   adafruit/Adafruit GFX Library
   AccelStepper
   RobTillaart/AS5600
+src_filter = +<receiver/*>
+
+[env:sender]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  adafruit/Adafruit SSD1306
+  adafruit/Adafruit GFX Library
+src_filter = +<sender/*>

--- a/src/receiver/main.cpp
+++ b/src/receiver/main.cpp
@@ -6,6 +6,7 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <AccelStepper.h>
+#include <WiFiUdp.h>
 
 #define PAN_ENCODER_ADDR  0x36
 #define TILT_ENCODER_ADDR 0x37
@@ -21,6 +22,11 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
 
 WebServer server(80);
 Preferences prefs;
+WiFiUDP udp;
+
+#define DISCOVERY_PORT 4210
+#define WIFI_BTN_PIN 0
+const char *DEVICE_NAME = "PTZ-Receiver";
 
 // Stepper driver pins
 #define PAN_STEP_PIN 32
@@ -165,6 +171,7 @@ bool connectWiFi() {
 void setup() {
     Serial.begin(115200);
     Wire.begin(OLED_SDA, OLED_SCL);
+    pinMode(WIFI_BTN_PIN, INPUT_PULLUP);
 
     if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
         Serial.println("OLED init failed");
@@ -177,7 +184,7 @@ void setup() {
     tiltAngle = readAS5600(TILT_ENCODER_ADDR);
     zoomAngle = readAS5600(ZOOM_ENCODER_ADDR);
   
-    if(!connectWiFi()) {
+    if(digitalRead(WIFI_BTN_PIN) == LOW || !connectWiFi()) {
         startConfigAP();
     }
 
@@ -185,10 +192,23 @@ void setup() {
     server.on("/", [](){ server.send(200, "text/plain", "Controller endpoint"); });
     server.on("/move", HTTP_GET, handleMove);
     server.begin();
+    udp.begin(DISCOVERY_PORT);
 }
 
 void loop() {
     server.handleClient();
+    int p = udp.parsePacket();
+    if (p) {
+        String msg;
+        while (udp.available()) {
+            msg += (char)udp.read();
+        }
+        if (msg == "DISCOVER_PTZ") {
+            udp.beginPacket(udp.remoteIP(), udp.remotePort());
+            udp.write((const uint8_t*)DEVICE_NAME, strlen(DEVICE_NAME));
+            udp.endPacket();
+        }
+    }
     panStepper.run();
     tiltStepper.run();
     zoomStepper.run();

--- a/src/sender/main.cpp
+++ b/src/sender/main.cpp
@@ -1,0 +1,202 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WebServer.h>
+#include <Preferences.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#include <WiFiUdp.h>
+#include <HTTPClient.h>
+#include <vector>
+
+#define OLED_SDA 21
+#define OLED_SCL 22
+
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+
+#define JOY_X_PIN 34
+#define JOY_Y_PIN 35
+#define JOY_BTN_PIN 0 // boot button can be used
+
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
+WebServer server(80);
+Preferences prefs;
+WiFiUDP udp;
+
+struct ReceiverInfo {
+    IPAddress ip;
+    String name;
+};
+std::vector<ReceiverInfo> receivers;
+IPAddress selectedReceiver;
+
+void showStatus(const String &msg) {
+    display.clearDisplay();
+    display.setCursor(0,0);
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.println(msg);
+    display.display();
+}
+
+void saveCredentials(const String &ssid, const String &pass) {
+    prefs.begin("wifi", false);
+    prefs.putString("ssid", ssid);
+    prefs.putString("pass", pass);
+    prefs.end();
+}
+
+void handleRoot() {
+    int n = WiFi.scanNetworks();
+    String options;
+    for (int i = 0; i < n; i++) {
+        options += "<option>" + WiFi.SSID(i) + "</option>";
+    }
+    String page = "<html><body><h1>Controller WiFi Setup</h1>";
+    page += "<form method='POST' action='/save'>";
+    page += "SSID:<br><select name='ssid'>" + options + "</select><br>";
+    page += "Password:<br><input name='pass' type='password'><br>";
+    page += "<input type='submit' value='Save'></form></body></html>";
+    server.send(200, "text/html", page);
+}
+
+void handleSave() {
+    if (server.hasArg("ssid") && server.hasArg("pass")) {
+        String ssid = server.arg("ssid");
+        String pass = server.arg("pass");
+        saveCredentials(ssid, pass);
+        server.send(200, "text/plain", "Saved. Rebooting...");
+        delay(1000);
+        ESP.restart();
+    } else {
+        server.send(400, "text/plain", "Missing fields");
+    }
+}
+
+void startConfigAP() {
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP("Controller-Setup");
+    IPAddress ip = WiFi.softAPIP();
+    showStatus(String("AP: ") + ip.toString());
+
+    server.on("/", handleRoot);
+    server.on("/save", HTTP_POST, handleSave);
+    server.begin();
+
+    while (true) {
+        server.handleClient();
+        delay(10);
+    }
+}
+
+bool connectWiFi() {
+    prefs.begin("wifi", true);
+    String ssid = prefs.getString("ssid", "");
+    String pass = prefs.getString("pass", "");
+    prefs.end();
+
+    if (ssid.isEmpty()) {
+        return false;
+    }
+
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid.c_str(), pass.c_str());
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED && millis() - start < 15000) {
+        delay(500);
+        showStatus("Connecting...\n" + ssid);
+    }
+    return WiFi.status() == WL_CONNECTED;
+}
+
+void discoverReceivers() {
+    receivers.clear();
+    const char *msg = "DISCOVER_PTZ";
+    udp.begin(4210);
+    udp.beginPacket(IPAddress(255,255,255,255), 4210);
+    udp.write((const uint8_t*)msg, strlen(msg));
+    udp.endPacket();
+
+    unsigned long start = millis();
+    while (millis() - start < 3000) {
+        int p = udp.parsePacket();
+        if (p) {
+            ReceiverInfo info;
+            info.ip = udp.remoteIP();
+            String name;
+            while (udp.available()) {
+                name += (char)udp.read();
+            }
+            info.name = name;
+            receivers.push_back(info);
+        }
+        delay(10);
+    }
+    udp.stop();
+}
+
+void showReceivers() {
+    display.clearDisplay();
+    display.setCursor(0,0);
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.println("Receivers:");
+    for (size_t i=0; i<receivers.size() && i<4; ++i) {
+        display.setCursor(0, 10 + i*10);
+        display.print(i+1);
+        display.print(": ");
+        display.print(receivers[i].ip);
+    }
+    display.display();
+    if (!receivers.empty()) {
+        selectedReceiver = receivers[0].ip;
+    }
+}
+
+void sendControl() {
+    if (selectedReceiver == IPAddress()) return;
+    static float filtX = analogRead(JOY_X_PIN);
+    static float filtY = analogRead(JOY_Y_PIN);
+    float rawX = analogRead(JOY_X_PIN);
+    float rawY = analogRead(JOY_Y_PIN);
+    // simple exponential moving average to smooth joystick noise
+    const float alpha = 0.3f;
+    filtX = filtX * (1.0f - alpha) + rawX * alpha;
+    filtY = filtY * (1.0f - alpha) + rawY * alpha;
+    int pan = map((int)filtX, 0, 4095, -1000, 1000);
+    int tilt = map((int)filtY, 0, 4095, -1000, 1000);
+    String url = String("http://") + selectedReceiver.toString() + "/move?pan=" + pan + "&tilt=" + tilt;
+    HTTPClient http;
+    http.begin(url);
+    http.GET();
+    http.end();
+}
+
+void setup() {
+    Serial.begin(115200);
+    pinMode(JOY_BTN_PIN, INPUT_PULLUP);
+    Wire.begin(OLED_SDA, OLED_SCL);
+    if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+        Serial.println("OLED init failed");
+    }
+    showStatus("Booting...");
+
+    if(digitalRead(JOY_BTN_PIN) == LOW || !connectWiFi()) {
+        startConfigAP();
+    }
+
+    showStatus("WiFi Connected\nIP: " + WiFi.localIP().toString());
+    discoverReceivers();
+    showReceivers();
+}
+
+unsigned long lastSend = 0;
+void loop() {
+    if (millis() - lastSend > 200) {
+        sendControl();
+        lastSend = millis();
+    }
+    delay(10);
+}
+


### PR DESCRIPTION
## Summary
- update README with instructions for sender & receiver builds
- smooth joystick input using an exponential moving average
- add Wi-Fi button check and UDP discovery response to the receiver

## Testing
- `platformio run -e sender` *(fails: platformio not installed)*
- `platformio run -e receiver` *(fails: platformio not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad30053083238cd6db51a4fcd87a