### PR TITLE
Fix WiFi config check in setup()

### DIFF
--- a/src/receiver/main.cpp
+++ b/src/receiver/main.cpp
@@ -185,10 +185,7 @@ void setup() {
     tiltAngle = readAS5600(TILT_ENCODER_ADDR);
     zoomAngle = readAS5600(ZOOM_ENCODER_ADDR);
   
-    if(digitalRead(WIFI_BTN_PIN) == LOW || !connectWiFi()) {
-
-    if(!connectWiFi()) {
-
+    if (digitalRead(WIFI_BTN_PIN) == LOW || !connectWiFi()) {
         startConfigAP();
     }
 


### PR DESCRIPTION
## Summary
- fix malformed WiFi button logic in `receiver` firmware

## Testing
- `platformio run -e receiver` *(fails: `platformio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842b2b46c8083239bc4a4c56e8cfd8b