### PR TITLE
Fix syntax error in crc16_struct

### DIFF
--- a/common/ptz_proto.h
+++ b/common/ptz_proto.h
@@ -47,8 +47,7 @@ template <typename T> constexpr uint16_t crc16_struct() {
   union U {
     T obj;
     uint8_t bytes[sizeof(T)];
-    constexpr U() : bytes{} {}  // keep 'bytes' active for constant evaluation
-  } u;
+    constexpr U() : bytes{} {} // keep 'bytes' active for constant evaluation
   } u{};
   return crc16_calc(u.bytes);
 }


### PR DESCRIPTION
## Summary
- fix spurious brace in `crc16_struct` implementation to restore valid C++

## Testing
- `g++ -std=c++17 test/test_main.cpp -Icommon -o /tmp/test` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842e590bfb08323bbf01fc1004ebd5c