### PR TITLE
Remove WiFi.begin from ESP-NOW STA setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Firmware for an ESP32 based pan/tilt head and its remote controller.
 
 ## Implemented MUST features
-- ESP-NOW communication with AES encryption
+- ESP-NOW communication with AES encryption (no Wi-Fi association required)
 - Common PTZ protocol with compile time CRC
 - Motion controller with encoder watchdog and soft limits
 - Joystick based controller UI on OLED display

--- a/common/wifi_link.cpp
+++ b/common/wifi_link.cpp
@@ -11,12 +11,7 @@ static void onSent(const uint8_t *, esp_now_send_status_t) {}
 bool WiFiLink::beginSTA(const uint8_t peer[6], RecvCallback cb) {
   WiFi.mode(WIFI_STA);
   WiFi.disconnect(false, true);
-  if (!WiFi.begin()) {
-    return false;
-  }
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(100);
-  }
+  // ESP-NOW does not require connection to an access point
   if (esp_now_init() != ESP_OK)
     return false;
   esp_now_register_send_cb(onSent);

--- a/common/wifi_link.h
+++ b/common/wifi_link.h
@@ -9,7 +9,9 @@ class WiFiLink {
 public:
   using RecvCallback = std::function<void(const uint8_t *data, size_t len)>;
 
+  // Initialize ESP-NOW in station mode. Does not connect to an AP.
   bool beginSTA(const uint8_t peer[6], RecvCallback cb);
+  // Initialize ESP-NOW in soft AP mode for the controller.
   bool beginAP(RecvCallback cb);
   bool send(const uint8_t peer[6], const void *msg, size_t len);
 


### PR DESCRIPTION
## Summary
- initialize ESP‑NOW without connecting to an AP in `WiFiLink::beginSTA`
- clarify in `WiFiLink` header that no AP association is needed
- mention in README that ESP‑NOW does not require Wi‑Fi association

## Testing
- `g++ -std=c++17 test/test_main.cpp -lgtest -lpthread -Icommon -o test_main && ./test_main`
- `~/.local/bin/platformio run -e controller`
- `~/.local/bin/platformio run -e head`


------
https://chatgpt.com/codex/tasks/task_e_6842eeb148c48323a60f7a1957e0e9ce