### PR TITLE
Load peer MACs from preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ platformio run -e controller  # build controller firmware
 
 Upload with `--target upload` as usual.
 
+
 ## Testing
 Run the unit tests using PlatformIO's native environment:
 
@@ -36,6 +37,26 @@ After a few seconds with no input the menu closes and the limits are saved.
 Copy `common/secrets.example.h` to `common/secrets.h` and edit the
 `WIFI_KEY` array with your own 16‑byte key before building. The
 `secrets.h` file is excluded from version control via `.gitignore`.
+
+## Configuring MAC addresses
+Each device needs to know the MAC address of its peer. You can read the
+hardware MAC of an ESP32 by uploading the following sketch and checking the
+serial output:
+
+```cpp
+#include <WiFi.h>
+void setup() {
+  Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
+  Serial.println(WiFi.macAddress());
+}
+void loop() {}
+```
+
+Copy the printed address of each board into `common/secrets.h` (variables
+`CONTROLLER_MAC` and `HEAD_MAC`) or store them in Preferences using the keys
+`controller` and `head` under the `wifi` namespace before flashing the final
+firmware.
 
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -3,7 +3,9 @@
 #include "SoftLimitMenu.h"
 #include "ptz_proto.h"
 #include "wifi_link.h"
+#include "secrets.h"
 #include <Arduino.h>
+#include <Preferences.h>
 
 using namespace ptz;
 
@@ -11,7 +13,8 @@ static WiFiLink wifiLink;
 static Joystick joy;
 static OledUI ui;
 static SoftLimitMenu menu;
-static uint8_t headMac[6] = {0, 0, 0, 0, 0, 0};
+static Preferences prefs;
+static uint8_t headMac[6];
 static HeadStatus lastStatus{};
 
 static void onRecv(const uint8_t *data, size_t len) {
@@ -22,6 +25,15 @@ static void onRecv(const uint8_t *data, size_t len) {
 
 void setup() {
   Serial.begin(115200);
+  prefs.begin("wifi", true);
+  if (prefs.getBytes("head", headMac, 6) != 6) {
+    memcpy(headMac, HEAD_MAC, 6);
+  }
+  prefs.end();
+  static const uint8_t unset[6] = {0, 0, 0, 0, 0, 0};
+  if (memcmp(headMac, unset, 6) == 0) {
+    Serial.println("WARNING: head MAC address not configured");
+  }
   Wire.begin();
   joy.begin(34, 35);
   ui.begin();

--- a/head/src/main.cpp
+++ b/head/src/main.cpp
@@ -1,14 +1,17 @@
 #include "MotionController.h"
 #include "ptz_proto.h"
 #include "wifi_link.h"
+#include "secrets.h"
 #include <Arduino.h>
+#include <Preferences.h>
 #include <Wire.h>
 
 using namespace ptz;
 
 static WiFiLink wifiLink;
 static MotionController motion;
-static uint8_t controllerMac[6] = {0, 0, 0, 0, 0, 0};
+static Preferences prefs;
+static uint8_t controllerMac[6];
 
 static void onRecv(const uint8_t *data, size_t len) {
   if (len == sizeof(HeadCmd)) {
@@ -19,6 +22,15 @@ static void onRecv(const uint8_t *data, size_t len) {
 
 void setup() {
   Serial.begin(115200);
+  prefs.begin("wifi", true);
+  if (prefs.getBytes("controller", controllerMac, 6) != 6) {
+    memcpy(controllerMac, CONTROLLER_MAC, 6);
+  }
+  prefs.end();
+  static const uint8_t unset[6] = {0, 0, 0, 0, 0, 0};
+  if (memcmp(controllerMac, unset, 6) == 0) {
+    Serial.println("WARNING: controller MAC address not configured");
+  }
   Wire.begin();
   motion.begin();
   wifiLink.beginSTA(controllerMac, onRecv);


### PR DESCRIPTION
## Summary
- read peer MACs from the `wifi` preference space if available
- fall back to constants in `secrets.h`
- warn when MAC addresses are still the default
- document how to discover and configure MAC addresses

## Testing
- `~/.local/bin/pio run -e controller`
- `~/.local/bin/pio run -e head`

------
https://chatgpt.com/codex/tasks/task_e_6842eeccefe883238d0672cdab2a1a33