### PR TITLE
Add MAC placeholders in secrets example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ After a few seconds with no input the menu closes and the limits are saved.
 
 ### Private WiFi key
 Copy `common/secrets.example.h` to `common/secrets.h` and edit the
-`WIFI_KEY` array with your own 16‑byte key before building. The
-`secrets.h` file is excluded from version control via `.gitignore`.
+`WIFI_KEY` array with your own 16‑byte key before building. The file also
+contains placeholders for `CONTROLLER_MAC` and `HEAD_MAC` which you may fill
+with the MAC addresses of your boards. The `secrets.h` file is excluded from
+version control via `.gitignore`.
 
 ## Configuring MAC addresses
 Each device needs to know the MAC address of its peer. You can read the

--- a/common/secrets.example.h
+++ b/common/secrets.example.h
@@ -6,3 +6,7 @@ static const uint8_t WIFI_KEY[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
+
+// Replace with the MAC addresses of your controller and head boards
+static const uint8_t CONTROLLER_MAC[6] = {0, 0, 0, 0, 0, 0};
+static const uint8_t HEAD_MAC[6] = {0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
## Summary
- add default CONTROLLER_MAC and HEAD_MAC placeholder arrays
- mention MAC placeholders in README instructions

## Testing
- `platformio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6847e149a6048323a6970a2d4d196193