### PR TITLE
Wire zoom detection into UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Firmware for an ESP32 based pan/tilt head and its remote controller.
 - Common PTZ protocol with compile time CRC
 - Motion controller with encoder watchdog and soft limits
 - Joystick based controller UI on OLED display
+- Automatic detection of zoom lens with indicator on the controller display
 
 ## Building
 Install PlatformIO and run:

--- a/common/ptz_proto.h
+++ b/common/ptz_proto.h
@@ -27,6 +27,7 @@ constexpr int16_t TILT_MIN = -120;
 constexpr int16_t TILT_MAX = 120;
 
 constexpr uint8_t FLAG_ENCODER_ERR = 0x01;
+constexpr uint8_t FLAG_ZOOM_PRESENT = 0x02;
 
 constexpr uint16_t crc16_byte(uint16_t crc, uint8_t data) {
   crc ^= data;

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -50,6 +50,7 @@ void loop() {
     wifiLink.send(headMac, &cmd, sizeof(cmd));
     lastSend = millis();
   }
-  ui.update(lastStatus, true);
+  bool zoom = lastStatus.flags & FLAG_ZOOM_PRESENT;
+  ui.update(lastStatus, zoom);
   delay(10);
 }

--- a/head/src/main.cpp
+++ b/head/src/main.cpp
@@ -1,5 +1,6 @@
 #include "MotionController.h"
 #include "ptz_proto.h"
+#include "ZoomDetect.h"
 #include "wifi_link.h"
 #include "secrets.h"
 #include <Arduino.h>
@@ -10,6 +11,8 @@ using namespace ptz;
 
 static WiFiLink wifiLink;
 static MotionController motion;
+static ZoomDetect zoomDet;
+static bool zoomPresent = false;
 static Preferences prefs;
 static uint8_t controllerMac[6];
 
@@ -32,6 +35,7 @@ void setup() {
     Serial.println("WARNING: controller MAC address not configured");
   }
   Wire.begin();
+  zoomPresent = zoomDet.zoomPresent();
   motion.begin();
   wifiLink.beginSTA(controllerMac, onRecv);
 }
@@ -40,7 +44,10 @@ unsigned long lastStatus = 0;
 void loop() {
   motion.task();
   if (millis() - lastStatus >= 10) {
-    HeadStatus st{motion.panDeg(), motion.tiltDeg(), 0, motion.flags()};
+    uint8_t flags = motion.flags();
+    if (zoomPresent)
+      flags |= FLAG_ZOOM_PRESENT;
+    HeadStatus st{motion.panDeg(), motion.tiltDeg(), 0, flags};
     wifiLink.send(controllerMac, &st, sizeof(st));
     lastStatus = millis();
   }


### PR DESCRIPTION
## Summary
- expose zoom lens presence in the protocol
- detect zoom on the head and send a flag
- show zoom status on controller
- document zoom detection feature

## Testing
- `platformio test -e native`

------
https://chatgpt.com/codex/tasks/task_e_6847e2fc67dc83238e7eb4644a086eeb